### PR TITLE
Unroll 32affba6 (stairs)

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -1,4 +1,4 @@
-
+﻿
 --[[
 
   Nether mod for minetest
@@ -519,13 +519,6 @@ if minetest.get_modpath("moreblocks") then
 			sounds = default.node_sound_stone_defaults(),
 	})
 end
-
-stairs.register_stair_and_slab("brick", "nether:brick",
-	{cracky=3, oddly_breakable_by_hand=1},
-	{"nether_brick.png"},
-	"nether stair",
-	"nether slab",
-	default.node_sound_stone_defaults())
 
 
 -- Craftitems


### PR DESCRIPTION
Looks like some sort of merge problem:

32affba6 re-registered stairs which have already been registered 20 lines earlier in the code, and it registered them as "brick" instead of "nether_brick", causing the netherbrick stairs to replace Minetest's default:brick stairs. The rest of 32affba6 has already been unrolled in 7a0e52da, but the stairs bug remained.

![stairsbug](https://user-images.githubusercontent.com/6390507/61178623-fe35ea80-a633-11e9-8fa3-fbf90a899d8b.png)

Fixing this bug means brick stairs will appear in the Nether anywhere a player has previously laid netherbrick stairs, however generated dungeons are fine as the dungeon generation does not currently create netherbrick stairs.