### PR TITLE
Compatibility with 5.0.0+

### DIFF
--- a/depends.txt
+++ b/depends.txt
@@ -1,3 +1,0 @@
-stairs
-default
-moreblocks?

--- a/description.txt
+++ b/description.txt
@@ -1,1 +1,0 @@
-Adds a deep underground realm with different mapgen that you can reach with obsidian portals.

--- a/init.lua
+++ b/init.lua
@@ -296,13 +296,13 @@ minetest.register_abm({
 					end
 					-- teleport the player
 					minetest.after(3, function(o, p, t)
-						local objpos = o:getpos()
+						local objpos = o:get_pos()
 						objpos.y = objpos.y + 0.1 -- Fix some glitches at -8000
 						if minetest.get_node(objpos).name ~= "nether:portal" then
 							return
 						end
 
-						o:setpos(t)
+						o:set_pos(t)
 
 						local function check_and_build_portal(pp, tt)
 							local n = minetest.get_node_or_nil(tt)

--- a/mod.conf
+++ b/mod.conf
@@ -1,1 +1,4 @@
 name = nether
+depends = stairs, default
+optional_depends = moreblocks
+description = Adds a deep underground realm with different mapgen that you can reach with obsidian portals.


### PR DESCRIPTION
Compatibility with MT/MTG 5.0.0 and above:

- Replace `depends.txt` and `description.txt` with `mod.conf`.
- Replace deprecated functions with newer ones.