### PR TITLE
Fixed a bug where players quit when teleporting

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -295,7 +295,7 @@ minetest.register_abm({
 							vector.subtract(target, 4), vector.add(target, 4))
 					end
 					-- teleport the player
-					minetest.after(3, function(o, p, t)
+					minetest.after(3, function(o, p, t) pcall(function() -- avoid crashes when players exit
 						local objpos = o:getpos()
 						objpos.y = objpos.y + 0.1 -- Fix some glitches at -8000
 						if minetest.get_node(objpos).name ~= "nether:portal" then
@@ -317,7 +317,7 @@ minetest.register_abm({
 
 						minetest.after(1, check_and_build_portal, p, t)
 
-					end, obj, pos, target)
+					end) end, obj, pos, target)
 				end
 			end
 		end

--- a/init.lua
+++ b/init.lua
@@ -295,9 +295,9 @@ minetest.register_abm({
 							vector.subtract(target, 4), vector.add(target, 4))
 					end
 					-- teleport the player
-					minetest.after(3, function(o, p, t) function()
+					minetest.after(3, function(o, p, t)
 						local objpos = o:getpos()
-						if not objpos then -- player not exist
+						if not objpos then -- player quit the game while teleporting
 							return
 						end
 						objpos.y = objpos.y + 0.1 -- Fix some glitches at -8000

--- a/init.lua
+++ b/init.lua
@@ -295,8 +295,11 @@ minetest.register_abm({
 							vector.subtract(target, 4), vector.add(target, 4))
 					end
 					-- teleport the player
-					minetest.after(3, function(o, p, t) pcall(function() -- avoid crashes when players exit
+					minetest.after(3, function(o, p, t) function()
 						local objpos = o:getpos()
+						if not objpos then -- player not exist
+							return
+						end
 						objpos.y = objpos.y + 0.1 -- Fix some glitches at -8000
 						if minetest.get_node(objpos).name ~= "nether:portal" then
 							return
@@ -317,7 +320,7 @@ minetest.register_abm({
 
 						minetest.after(1, check_and_build_portal, p, t)
 
-					end) end, obj, pos, target)
+					end, obj, pos, target)
 				end
 			end
 		end


### PR DESCRIPTION
logs of my server ( username removed)
```
2020-01-05 08:15:15: ACTION[Server]: ... leaves game. List of players: 
2020-01-05 08:15:17: ACTION[Main]: Server: Shutting down
2020-01-05 08:15:18: ERROR[Main]: ServerError: AsyncErr: environment_Step: Runtime error from mod 'nether' in callback environment_Step(): /root/.minetest/mods/nether/init.lua:300: attempt to index local 'objpos' (a nil value)
2020-01-05 08:15:18: ERROR[Main]: stack traceback:
2020-01-05 08:15:18: ERROR[Main]: 	/root/.minetest/mods/nether/init.lua:300: in function 'func'
2020-01-05 08:15:18: ERROR[Main]: 	...c709f/usr/bin/../share/minetest/builtin/common/after.lua:20: in function <...c709f/usr/bin/../share/minetest/builtin/common/after.lua:5>
2020-01-05 08:15:18: ERROR[Main]: 	...709f/usr/bin/../share/minetest/builtin/game/register.lua:429: in function <...709f/usr/bin/../share/minetest/builtin/game/register.lua:413>
2020-01-05 08:15:18: ERROR[Main]: stack traceback:
```