### PR TITLE
Fix logic bug in parsing of nether_realm_enabled

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -49,7 +49,7 @@ nether.NETHER_REALM_ENABLED       =  true -- Setting to false disables the Nethe
 -- Override default settings with values from the .conf file, if any are present.
 nether.FASTTRAVEL_FACTOR          = tonumber(minetest.settings:get("nether_fasttravel_factor") or nether.FASTTRAVEL_FACTOR)
 nether.PORTAL_BOOK_LOOT_WEIGHTING = tonumber(minetest.settings:get("nether_portalBook_loot_weighting") or nether.PORTAL_BOOK_LOOT_WEIGHTING)
-nether.NETHER_REALM_ENABLED       = minetest.settings:get_bool("nether_realm_enabled", nether.NETHER_REALM_ENABLED) or nether.NETHER_REALM_ENABLED
+nether.NETHER_REALM_ENABLED       = minetest.settings:get_bool("nether_realm_enabled", nether.NETHER_REALM_ENABLED)
 
 
 -- Load files


### PR DESCRIPTION
The second argument of minetest.settings:get_bool is the default value (for when the configuration value is not set). Remove the superfluous `or nether.NETHER_REALM_ENABLED` which rendered the config option useless, because it always forced the variable to true.