### PR TITLE
Reduce lava in biomes-based mapgen

### DIFF
--- a/mapgen.lua
+++ b/mapgen.lua
@@ -113,7 +113,7 @@ override_underground_biomes()
 
 -- nether:native_mapgen is used to prevent ores and decorations being generated according
 -- to landforms created by the native mapgen.
--- Ores and decorations are registered against "nether:rack" instead, and the lua
+-- Ores and decorations can be registered against "nether:rack" instead, and the lua
 -- on_generate() callback will carve the Nether with nether:rack before invoking
 -- generate_decorations and generate_ores.
 minetest.register_node("nether:native_mapgen", {})
@@ -160,7 +160,7 @@ minetest.register_ore({
 	ore_type       = "scatter",
 	ore            = "default:lava_source",
 	wherein        = "nether:rack",
-	clust_scarcity = 32 * 32 * 32,
+	clust_scarcity = 36 * 36 * 36,
 	clust_num_ores = 4,
 	clust_size     = 2,
 	y_max = NETHER_CEILING,

--- a/mapgen_decorations.lua
+++ b/mapgen_decorations.lua
@@ -113,7 +113,7 @@ minetest.register_decoration({
     deco_type = "schematic",
     place_on = "nether:rack",
     sidelen = 80,
-    fill_ratio = 0.0004,
+    fill_ratio = 0.0003,
     biomes = {"nether_caverns"},
     y_max = nether.DEPTH_CEILING, -- keep compatibility with mapgen_nobiomes.lua
     y_min = nether.DEPTH_FLOOR,
@@ -127,7 +127,7 @@ minetest.register_decoration({
     deco_type = "schematic",
     place_on = "nether:rack",
     sidelen = 80,
-    fill_ratio = 0.0007,
+    fill_ratio = 0.0008,
     biomes = {"nether_caverns"},
     y_max = nether.DEPTH_CEILING, -- keep compatibility with mapgen_nobiomes.lua
     y_min = nether.DEPTH_FLOOR,


### PR DESCRIPTION
I'll merge this myself eventually, so this PR is more of a heads-up and opportunity for anyone to comment, object, or tune.

The biomes-based mapgen creates the same amount of lava ores as the original nether mapgen, but it doesn't have the same issue of chunk emerge order causing lava ores in the overdraw regions to randomly get removed. This adjustment will hopefully balance that difference out a little. (see also paramat's comment about [why too much lava isn't necessarily desireable](https://github.com/minetest-mods/nether/issues/4#issuecomment-506986647), plus I'm also hoping to add [a new region](https://forum.minetest.net/viewtopic.php?p=375637#p375637) to the nether at some point with lava seas - so people can get their lava-pool fix that way)

Also makes glowstone stalactites a bit rarer.

Adjusting lava ore scarcity in the biomes-based mapgen doesn't cause forwards or backwards compatibilty issues with existing maps, likewise with schematic rarety like glowstone stalactites, so we can afford to fiddle and tune with the biomes-based mapgen.