### PR TITLE
Respect protected areas when spawning remote portals

### DIFF
--- a/.luacheckrc
+++ b/.luacheckrc
@@ -23,6 +23,7 @@ read_globals = {
 	"PseudoRandom",
 	"stairs",
 	"stairsplus",
+	"string.split",
 	table = { fields = { "copy", "getn" } },
 	"vector",
 	"VoxelArea",

--- a/init.lua
+++ b/init.lua
@@ -58,7 +58,7 @@ nether.NETHER_REALM_ENABLED       = minetest.settings:get_bool("nether_realm_ena
 nether.DEPTH_CEILING              = tonumber(minetest.settings:get("nether_depth_ymax") or nether.DEPTH_CEILING)
 nether.DEPTH_FLOOR                = tonumber(minetest.settings:get("nether_depth_ymin") or nether.DEPTH_FLOOR)
 
-if nether.DEPTH_FLOOR + 1000 > nether.DEPTH_CEILING then 
+if nether.DEPTH_FLOOR + 1000 > nether.DEPTH_CEILING then
 	error("The lower limit of the Nether must be set at least 1000 lower than the upper limit, and more than 3000 is recommended. Set settingtypes.txt, or 'All Settings' -> 'Mods' -> 'nether' -> 'Nether depth'", 0)
 end
 nether.DEPTH = nether.DEPTH_CEILING -- Deprecated, use nether.DEPTH_CEILING instead.
@@ -101,7 +101,7 @@ The expedition parties have found no diamonds or gold, and after an experienced 
 			return pos.y < nether.DEPTH_CEILING
 		end,
 
-		find_realm_anchorPos = function(surface_anchorPos)
+		find_realm_anchorPos = function(surface_anchorPos, player_name)
 			-- divide x and z by a factor of 8 to implement Nether fast-travel
 			local destination_pos = vector.divide(surface_anchorPos, nether.FASTTRAVEL_FACTOR)
 			destination_pos.x = math.floor(0.5 + destination_pos.x) -- round to int
@@ -116,12 +116,12 @@ The expedition parties have found no diamonds or gold, and after an experienced 
 				return existing_portal_location, existing_portal_orientation
 			else
 				local start_y = nether.DEPTH_CEILING - math.random(500, 1500) -- Search starting altitude
-				destination_pos.y = nether.find_nether_ground_y(destination_pos.x, destination_pos.z, start_y)
+				destination_pos.y = nether.find_nether_ground_y(destination_pos.x, destination_pos.z, start_y, player_name)
 				return destination_pos
 			end
 		end,
 
-		find_surface_anchorPos = function(realm_anchorPos)
+		find_surface_anchorPos = function(realm_anchorPos, player_name)
 			-- A portal definition doesn't normally need to provide a find_surface_anchorPos() function,
 			-- since find_surface_target_y() will be used by default, but Nether portals also scale position
 			-- to create fast-travel.
@@ -140,7 +140,7 @@ The expedition parties have found no diamonds or gold, and after an experienced 
 			if existing_portal_location ~= nil then
 				return existing_portal_location, existing_portal_orientation
 			else
-				destination_pos.y = nether.find_surface_target_y(destination_pos.x, destination_pos.z, "nether_portal")
+				destination_pos.y = nether.find_surface_target_y(destination_pos.x, destination_pos.z, "nether_portal", player_name)
 				return destination_pos
 			end
 		end,

--- a/mapgen.lua
+++ b/mapgen.lua
@@ -465,7 +465,8 @@ end
 
 
 -- use knowledge of the nether mapgen algorithm to return a suitable ground level for placing a portal.
-function nether.find_nether_ground_y(target_x, target_z, start_y)
+-- player_name is optional, allowing a player to spawn a remote portal in their own protected areas.
+function nether.find_nether_ground_y(target_x, target_z, start_y, player_name)
 	local nobj_cave_point = minetest.get_perlin(np_cave)
 	local air = 0 -- Consecutive air nodes found
 
@@ -479,10 +480,10 @@ function nether.find_nether_ground_y(target_x, target_z, start_y)
 				-- Check volume for non-natural nodes
 				local minp = {x = target_x - 1, y = y    , z = target_z - 2}
 				local maxp = {x = target_x + 2, y = y + 4, z = target_z + 2}
-				if nether.volume_is_natural(minp, maxp) then
+				if nether.volume_is_natural_and_unprotected(minp, maxp, player_name) then
 					return y + 1
 				else -- Restart search a little lower
-					nether.find_nether_ground_y(target_x, target_z, y - 16)
+					nether.find_nether_ground_y(target_x, target_z, y - 16, player_name)
 				end
 			else -- Not enough space, reset air to zero
 				air = 0

--- a/mapgen.lua
+++ b/mapgen.lua
@@ -470,6 +470,10 @@ function nether.find_nether_ground_y(target_x, target_z, start_y, player_name)
 	local nobj_cave_point = minetest.get_perlin(np_cave)
 	local air = 0 -- Consecutive air nodes found
 
+	local minp_schem, maxp_schem = nether.get_schematic_volume({x = target_x, y = 0, z = target_z}, nil, "nether_portal")
+	local minp = {x = minp_schem.x, y = 0, z = minp_schem.z}
+	local maxp = {x = maxp_schem.x, y = 0, z = maxp_schem.z}
+
 	for y = start_y, math_max(NETHER_FLOOR + BLEND, start_y - 4096), -1 do
 		local nval_cave = nobj_cave_point:get3d({x = target_x, y = y, z = target_z})
 
@@ -477,11 +481,12 @@ function nether.find_nether_ground_y(target_x, target_z, start_y, player_name)
 			air = air + 1
 		else -- Not cavern, check if 4 nodes of space above
 			if air >= 4 then
+				local portal_y = y + 1
 				-- Check volume for non-natural nodes
-				local minp = {x = target_x - 1, y = y    , z = target_z - 2}
-				local maxp = {x = target_x + 2, y = y + 4, z = target_z + 2}
+				minp.y = minp_schem.y + portal_y
+				maxp.y = maxp_schem.y + portal_y
 				if nether.volume_is_natural_and_unprotected(minp, maxp, player_name) then
-					return y + 1
+					return portal_y
 				else -- Restart search a little lower
 					nether.find_nether_ground_y(target_x, target_z, y - 16, player_name)
 				end

--- a/mapgen_nobiomes.lua
+++ b/mapgen_nobiomes.lua
@@ -206,6 +206,10 @@ function nether.find_nether_ground_y(target_x, target_z, start_y, player_name)
 	local nobj_cave_point = minetest.get_perlin(np_cave)
 	local air = 0 -- Consecutive air nodes found
 
+	local minp_schem, maxp_schem = nether.get_schematic_volume({x = target_x, y = 0, z = target_z}, nil, "nether_portal")
+	local minp = {x = minp_schem.x, y = 0, z = minp_schem.z}
+	local maxp = {x = maxp_schem.x, y = 0, z = maxp_schem.z}
+
 	for y = start_y, math.max(NETHER_FLOOR + BLEND, start_y - 4096), -1 do
 		local nval_cave = nobj_cave_point:get3d({x = target_x, y = y, z = target_z})
 
@@ -213,11 +217,12 @@ function nether.find_nether_ground_y(target_x, target_z, start_y, player_name)
 			air = air + 1
 		else -- Not cavern, check if 4 nodes of space above
 			if air >= 4 then
+				local portal_y = y + 1
 				-- Check volume for non-natural nodes
-				local minp = {x = target_x - 1, y = y    , z = target_z - 2}
-				local maxp = {x = target_x + 2, y = y + 4, z = target_z + 2}
+				minp.y = minp_schem.y + portal_y
+				maxp.y = maxp_schem.y + portal_y
 				if nether.volume_is_natural_and_unprotected(minp, maxp, player_name) then
-					return y + 1
+					return portal_y
 				else -- Restart search a little lower
 					nether.find_nether_ground_y(target_x, target_z, y - 16, player_name)
 				end

--- a/portal_api.lua
+++ b/portal_api.lua
@@ -2222,6 +2222,16 @@ end
 
 -- Deprecated, use nether.volume_is_natural_and_unprotected() instead.
 function nether.volume_is_natural(minp, maxp)
+
+	if nether.deprecation_warning_volume_is_natural == nil then
+		local stack = debug.traceback("", 2);
+		local calling_func = (string.split(stack, "\n", false, 2, false)[2] or ""):trim()
+		minetest.log("warning",
+			"Deprecated function \"nether.volume_is_natural()\" invoked. Use \"nether.volume_is_natural_and_unprotected()\" instead. " ..
+			calling_func)
+		nether.deprecation_warning_volume_is_natural = true;
+	end
+
 	return nether.volume_is_natural_and_unprotected(minp, maxp)
 end
 
@@ -2236,8 +2246,9 @@ function nether.get_schematic_volume(anchor_pos, orientation, portal_name)
 		local minp0, maxp0 = nether.get_schematic_volume(anchor_pos, 0, portal_name)
 		local minp1, maxp1 = nether.get_schematic_volume(anchor_pos, 1, portal_name)
 
-		-- due to the nature of schematic rotation, we don't need to check orientations
-		-- 3 and 4, even for asymmetric schematics.
+		-- ToDo: If an asymmetric portal is used with an anchor not at the center of the
+		-- schematic then we will also need to check orientations 3 and 4.
+		-- (The currently existing portal-shapes are not affected)
 		return
 			{x = math.min(minp0.x, minp1.x), y = math.min(minp0.y, minp1.y), z = math.min(minp0.z, minp1.z)},
 			{x = math.max(maxp0.x, maxp1.x), y = math.max(maxp0.y, maxp1.y), z = math.max(maxp0.z, maxp1.z)}

--- a/portal_api.txt
+++ b/portal_api.txt
@@ -56,7 +56,7 @@ Helper functions
       trees.
       Water will fail this test, unless it is unemerged.
     * player_name is optional, providing it allows the player's own protected
-      areas to be recognized as unprotected.
+      areas to be treated as unprotected.
 
 * `nether.find_surface_target_y(target_x, target_z, portal_name, player_name)`:
   returns a suitable anchorPos

--- a/portal_api.txt
+++ b/portal_api.txt
@@ -49,17 +49,22 @@ surface.
 Helper functions
 ----------------
 
-* `nether.volume_is_natural(minp, maxp)`: returns a boolean
+* `nether.volume_is_natural_and_unprotected(minp, maxp, player_name)`: returns
+  a boolean.
     * use this when determining where to spawn a portal, to avoid overwriting
       player builds. It checks the area for any nodes that aren't ground or
       trees.
       Water will fail this test, unless it is unemerged.
+    * player_name is optional, providing it allows the player's own protected
+      areas to be recognized as unprotected.
 
-* `nether.find_surface_target_y(target_x, target_z, portal_name)`: returns a
-  suitable anchorPos
+* `nether.find_surface_target_y(target_x, target_z, portal_name, player_name)`:
+  returns a suitable anchorPos
     * Can be used when implementing custom find_surface_anchorPos() functions
     * portal_name is optional, providing it allows existing portals on the
       surface to be reused.
+    * player_name is optional, providing it prevents the exclusion of surface
+      target areas which are protected by the player.
 
 * `nether.find_nearest_working_portal(portal_name, anchorPos, distance_limit, y_factor)`: returns
   (anchorPos, orientation), or nil if no portal was found within the
@@ -208,7 +213,7 @@ Used by `nether.register_portal`.
         -- Ideally implementations are fast, as this function can be used to
         -- sift through a list of portals.
 
-        find_realm_anchorPos = function(surface_anchorPos),
+        find_realm_anchorPos = function(surface_anchorPos, player_name),
         -- Required. Return a position in the realm that a portal created at
         -- surface_anchorPos will link to.
         -- Return an anchorPos or (anchorPos, orientation)
@@ -218,8 +223,10 @@ Used by `nether.register_portal`.
         -- orientation, otherwise the existing portal could be overwritten by
         -- a new one with the orientation of the surface portal.
         -- Return nil to prevent the portal from igniting.
+        -- player_name may be "", e.g. if the portal was ignited by a mesecon,
+        -- and is provided for use with volume_is_natural_and_unprotected() etc.
 
-        find_surface_anchorPos = function(realm_anchorPos),
+        find_surface_anchorPos = function(realm_anchorPos, player_name),
         -- Optional. If you don't implement this then a position near the
         -- surface will be picked.
         -- Return an anchorPos or (anchorPos, orientation)
@@ -233,6 +240,8 @@ Used by `nether.register_portal`.
         -- orientation, otherwise the existing portal could be overwritten by
         -- a new one with the orientation of the realm portal.
         -- Return nil to prevent the portal from igniting.
+        -- player_name may be "", e.g. if the portal was ignited by a mesecon,
+        -- and is provided for use with volume_is_natural_and_unprotected() etc.
 
         on_run_wormhole      = function(portalDef, anochorPos, orientation),
         -- invoked once per second per portal

--- a/portal_examples.lua
+++ b/portal_examples.lua
@@ -85,7 +85,7 @@ This portal is different to the others, rather than acting akin to a doorway it 
 			return pos.y > FLOATLAND_LEVEL - 200
 		end,
 
-		find_realm_anchorPos = function(surface_anchorPos)
+		find_realm_anchorPos = function(surface_anchorPos, player_name)
 			-- TODO: Once paramat finishes adjusting the floatlands, implement a surface algorithm that finds land
 			local destination_pos = {x = surface_anchorPos.x ,y = FLOATLAND_LEVEL + 2, z = surface_anchorPos.z}
 
@@ -131,13 +131,13 @@ Due to such difficulties, we never learned what determines the direction and dis
 			return true
 		end,
 
-		find_realm_anchorPos = function(surface_anchorPos)
+		find_realm_anchorPos = function(surface_anchorPos, player_name)
 			-- This function isn't needed, since this type of portal always goes to the surface
 			minetest.log("error" , "find_realm_anchorPos called for surface portal")
 			return {x=0, y=0, z=0}
 		end,
 
-		find_surface_anchorPos = function(realm_anchorPos)
+		find_surface_anchorPos = function(realm_anchorPos, player_name)
 			-- A portal definition doesn't normally need to provide a find_surface_anchorPos() function,
 			-- since find_surface_target_y() will be used by default, but these portals travel around the
 			-- surface (following a Moore curve) so will be calculating a different x and z to realm_anchorPos.
@@ -192,7 +192,7 @@ Due to such difficulties, we never learned what determines the direction and dis
 				end
 
 				local destination_pos = {x = target_x + adj_x, y = 0, z = target_z + adj_z}
-				destination_pos.y = nether.find_surface_target_y(destination_pos.x, destination_pos.z, "surface_portal")
+				destination_pos.y = nether.find_surface_target_y(destination_pos.x, destination_pos.z, "surface_portal", player_name)
 
 				return destination_pos
 			end


### PR DESCRIPTION
Fixes #26 

I've tested this a little, but I may test it more

~~It also raises the priority of an old bug - the volume that is checked before a portal is created does not exactly match the volume of nodes that are altered by placing the portal schematic. I think it's only out by a block tho.~~ Now fixed as part of this PR in 
ac557cf 
 
There's a very minor issue where the portal target is checked when the portal is ignited, but the remote portal schematic is not placed until someone walks through the portal. So if a protection is placed after the portal is ignited but before someone walks through it for the first time, then the protection will get ignored. I'll file that in the "don't care" basket ;)