### PR TITLE
Handle large protected depths

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -100,7 +100,7 @@ function nether.debug(message, ...)
 		end
 	end
 
-	local composed_message = string.format(message, unpack(args))
+	local composed_message = "nether: " .. string.format(message, unpack(args))
 
 	if math.floor(DEBUG_FLAGS / 1) % 2 == 1 then print(composed_message) end
 	if math.floor(DEBUG_FLAGS / 2) % 2 == 1 then minetest.chat_send_all(composed_message) end

--- a/portal_api.txt
+++ b/portal_api.txt
@@ -65,6 +65,8 @@ Helper functions
       surface to be reused.
     * player_name is optional, providing it prevents the exclusion of surface
       target areas which are protected by the player.
+    * May return nil in extreme circumstances, such as the surface being
+      protected down to a great depth.
 
 * `nether.find_nearest_working_portal(portal_name, anchorPos, distance_limit, y_factor)`: returns
   (anchorPos, orientation), or nil if no portal was found within the
@@ -222,7 +224,8 @@ Used by `nether.register_portal`.
         -- If the location of an existing portal is returned then include the
         -- orientation, otherwise the existing portal could be overwritten by
         -- a new one with the orientation of the surface portal.
-        -- Return nil to prevent the portal from igniting.
+        -- Return nil, or a position with a nil y component, to prevent the
+        -- portal from igniting.
         -- player_name may be "", e.g. if the portal was ignited by a mesecon,
         -- and is provided for use with volume_is_natural_and_unprotected() etc.
 
@@ -239,7 +242,8 @@ Used by `nether.register_portal`.
         -- If the location of an existing portal is returned then include the
         -- orientation, otherwise the existing portal could be overwritten by
         -- a new one with the orientation of the realm portal.
-        -- Return nil to prevent the portal from igniting.
+        -- Return nil, or a position with a nil y component, to prevent the
+        -- portal from igniting.
         -- player_name may be "", e.g. if the portal was ignited by a mesecon,
         -- and is provided for use with volume_is_natural_and_unprotected() etc.
 


### PR DESCRIPTION
Portals will now fail to ignite instead of defaulting to a fallback depth of (starty - 256) when no good target area can be found.
The search depth is also increased from (starty - 256) to (starty - 646)

This is to properly handle large protected areas that are sometimes set up at spawn - see issue #26

"Mysterious forces prevented you from opening that portal. Please try another location" is sent as a chat message to the player if no target destination can be found. (the ignition_failure_sound is also played)