### PR TITLE
climate_api support - add distance fog

### DIFF
--- a/.luacheckrc
+++ b/.luacheckrc
@@ -2,10 +2,12 @@ unused_args = false
 allow_defined_top = true
 
 globals = {
+	"bucket",
 	"nether"
 }
 
 read_globals = {
+	"climate_api",
 	"core",
 	"default",
 	"DIR_DELIM",

--- a/depends.txt
+++ b/depends.txt
@@ -6,3 +6,4 @@ fire?
 loot?
 mesecons?
 moreblocks?
+climate_api?

--- a/init.lua
+++ b/init.lua
@@ -253,13 +253,15 @@ The expedition parties have found no diamonds or gold, and after an experienced 
 				if pos.y <= nether.DEPTH_CEILING and pos.y >= nether.DEPTH_FLOOR then
 					result = "nether"
 
+					-- since mapgen_nobiomes.lua has no regions it doesn't implement getRegion(),
+					-- so only use getRegion() if it exists
 					if nether.mapgen.getRegion ~= nil then
 						-- the biomes-based mapgen supports 2 extra regions
 						local regions = nether.mapgen.RegionEnum
 						local region  = nether.mapgen.getRegion(pos)
-						if region == regions.Center or region == regions.CenterShell then
+						if region == regions.CENTER or region == regions.CENTERSHELL then
 							result = "mantle"
-						elseif region == regions.Negative or region == regions.NegativeShell then
+						elseif region == regions.NEGATIVE or region == regions.NEGATIVESHELL then
 							result = "geode"
 						end
 					end

--- a/locale/nether.fr.tr
+++ b/locale/nether.fr.tr
@@ -13,9 +13,25 @@ Construction requires 14 blocks of obsidian, which we found deep underground whe
 
 Nether Portal=Portail du Nether
 
+### mapgen_mantle.lua ###
+
+, @1m above lava-sea level=
+, @1m below lava-sea level=
+, approaching y boundary of Nether=
+@1@2@3@4=
+Center/Mantle, but outside the caverns=
+Center/Mantle, inside cavern=
+Describes which region of the nether the player is in=
+Negative nether=
+Positive nether=
+Shell between negative nether and center region=
+Shell between positive nether and center region=
+The Overworld=
+Unknown player position=
+[Perlin @1] =
+
 ### nodes.lua ###
 
-=
 A finely finished block of solid Nether Basalt.=
 A rough cut solid block of Nether Basalt.=
 A thin crust of cooled lava with liquid lava beneath=

--- a/locale/template.txt
+++ b/locale/template.txt
@@ -12,9 +12,25 @@ Construction requires 14 blocks of obsidian, which we found deep underground whe
 
 Nether Portal=
 
+### mapgen_mantle.lua ###
+
+, @1m above lava-sea level=
+, @1m below lava-sea level=
+, approaching y boundary of Nether=
+@1@2@3@4=
+Center/Mantle, but outside the caverns=
+Center/Mantle, inside cavern=
+Describes which region of the nether the player is in=
+Negative nether=
+Positive nether=
+Shell between negative nether and center region=
+Shell between positive nether and center region=
+The Overworld=
+Unknown player position=
+[Perlin @1] =
+
 ### nodes.lua ###
 
-=
 A finely finished block of solid Nether Basalt.=
 A rough cut solid block of Nether Basalt.=
 A thin crust of cooled lava with liquid lava beneath=

--- a/mapgen.lua
+++ b/mapgen.lua
@@ -45,7 +45,6 @@ local BASALT_COLUMN_LOWER_LIMIT = CENTER_CAVERN_LIMIT * 0.25      -- This value 
 
 -- Shared Nether mapgen namespace
 -- For mapgen files to share functions and constants
-nether.mapgen = {}
 local mapgen = nether.mapgen
 
 mapgen.TCAVE                     = TCAVE                     -- const needed in mapgen_mantle.lua
@@ -256,6 +255,19 @@ mapgen.np_cave = {
 	lacunarity = 2.0,
 	--flags = ""
 }
+
+local cavePointPerlin = nil
+
+mapgen.getCavePointPerlin = function()
+	cavePointPerlin = cavePointPerlin or minetest.get_perlin(mapgen.np_cave)
+	return cavePointPerlin
+end
+
+mapgen.getCavePerlinAt = function(pos)
+	cavePointPerlin = cavePointPerlin or minetest.get_perlin(mapgen.np_cave)
+	return cavePointPerlin:get3d(pos)
+end
+
 
 -- Buffers and objects we shouldn't recreate every on_generate
 
@@ -658,7 +670,7 @@ end
 -- use knowledge of the nether mapgen algorithm to return a suitable ground level for placing a portal.
 -- player_name is optional, allowing a player to spawn a remote portal in their own protected areas.
 function nether.find_nether_ground_y(target_x, target_z, start_y, player_name)
-	local nobj_cave_point = minetest.get_perlin(mapgen.np_cave)
+	local nobj_cave_point = mapgen.getCavePointPerlin()
 	local air = 0 -- Consecutive air nodes found
 
 	local minp_schem, maxp_schem = nether.get_schematic_volume({x = target_x, y = 0, z = target_z}, nil, "nether_portal")

--- a/mapgen.lua
+++ b/mapgen.lua
@@ -557,9 +557,12 @@ local function on_generated(minp, maxp, seed)
 		local tcave_adj, centerRegionLimit_adj = mapgen.get_mapgenblend_adjustments(y)
 		local tcave   = TCAVE + tcave_adj
 		local tmantle = CENTER_REGION_LIMIT + centerRegionLimit_adj -- cavern_noise_adj already contains central_region_limit_adj, so tmantle is only for comparisons when cavern_noise_adj hasn't been added to the noise value
+
+		 -- cavern_noise_adj gets added to noise value instead of added to the limit np_noise
+		 -- is compared against, so subtract centerRegionLimit_adj instead of adding
 		local cavern_noise_adj =
 			CENTER_REGION_LIMIT * (cavern_limit_distance * cavern_limit_distance * cavern_limit_distance) -
-			centerRegionLimit_adj -- cavern_noise_adj gets added to noise value instead of added to the limit np_noise is compared against, so subtract centerRegionLimit_adj instead of adding
+			centerRegionLimit_adj
 
 		for z = z0, z1 do
 			local vi = area:index(x0, y, z) -- Initial voxelmanip index

--- a/mapgen_mantle.lua
+++ b/mapgen_mantle.lua
@@ -49,7 +49,6 @@ local np_basalt = {
 
 local nobj_basalt = nil
 local nbuf_basalt = {}
-local cavePerlin = nil
 
 -- Content ids
 
@@ -414,52 +413,84 @@ mapgen.excavate_tunnel_to_center_of_the_nether = function(data, area, nvals_cave
 end
 
 
+-- an enumerated list of the different regions in the nether
+mapgen.RegionEnum = {
+	Overworld     = "overworld",      -- Outside the Nether / none of the regions in the Nether
+	Positive      = "positive",       -- The classic nether caverns are here - where cavePerlin > 0.6
+	PositiveShell = "positive shell", -- the nether side of the wall/buffer area separating classic nether from the mantle
+	Center        = "center",         -- The Mantle caverns are here
+	CenterShell   = "center shell",   -- the mantle side of the wall/buffer area separating the positive and negative regions from the center region
+	Negative      = "negative",       -- Secondary/spare region - where cavePerlin < -0.6
+	NegativeShell = "negative shell", -- the spare region side of the wall/buffer area separating the negative region from the mantle
+}
+
+
+-- Returns (region, noise) where region is a value from mapgen.RegionEnum
+-- and noise is the unadjusted cave perlin value
+mapgen.getRegion = function(pos)
+
+	if pos.y > nether.DEPTH_CEILING or pos.y < nether.DEPTH_FLOOR then
+		return mapgen.RegionEnum.Overworld, nil
+	end
+
+	local caveNoise = mapgen.getCavePerlinAt(pos)
+	local sea_level, cavern_limit_distance = mapgen.find_nearest_lava_sealevel(pos.y)
+	local tcave_adj, centerRegionLimit_adj = mapgen.get_mapgenblend_adjustments(pos.y)
+	local tcave   = mapgen.TCAVE + tcave_adj
+	local tmantle = mapgen.CENTER_REGION_LIMIT + centerRegionLimit_adj
+	local cavern_noise_adj =
+		mapgen.CENTER_REGION_LIMIT * (cavern_limit_distance * cavern_limit_distance * cavern_limit_distance) -
+		centerRegionLimit_adj -- cavern_noise_adj gets added to noise value instead of added to the limit np_noise is compared against, so subtract centerRegionLimit_adj so subtract centerRegionLimit_adj instead of adding
+
+	local region
+	if caveNoise > tcave then
+		region = mapgen.RegionEnum.Positive
+	elseif -caveNoise > tcave then
+		region = mapgen.RegionEnum.Negative
+	elseif math_abs(caveNoise) < tmantle then
+
+		if math_abs(caveNoise) + cavern_noise_adj < mapgen.CENTER_CAVERN_LIMIT then
+			region = mapgen.RegionEnum.Center
+		else
+			region = mapgen.RegionEnum.CenterShell
+		end
+
+	elseif caveNoise > 0 then
+		region = mapgen.RegionEnum.PositiveShell
+	else
+		region = mapgen.RegionEnum.NegativeShell
+	end
+
+	return region, caveNoise
+end
+
+
 minetest.register_chatcommand("nether_whereami",
-    {
+	{
 		description = "Describes which region of the nether the player is in",
 		privs = {debug = true},
 		func = function(name, param)
 
 			local player = minetest.get_player_by_name(name)
 			if player == nil then return false, "Unknown player position" end
+			local playerPos = vector.round(player:get_pos())
 
-			local pos = vector.round(player:get_pos())
-			if pos.y > nether.DEPTH_CEILING or pos.y < nether.DEPTH_FLOOR then
-				return true, "The Overworld"
-			end
+			local region, caveNoise                = mapgen.getRegion(playerPos)
+			local seaLevel, cavernLimitDistance    = mapgen.find_nearest_lava_sealevel(playerPos.y)
+			local tcave_adj, centerRegionLimit_adj = mapgen.get_mapgenblend_adjustments(playerPos.y)
 
-			cavePerlin = cavePerlin or minetest.get_perlin(mapgen.np_cave)
-			local densityNoise = cavePerlin:get_3d(pos)
-			local sea_level, cavern_limit_distance = mapgen.find_nearest_lava_sealevel(pos.y)
-			local tcave_adj, centerRegionLimit_adj = mapgen.get_mapgenblend_adjustments(pos.y)
-			local tcave   = mapgen.TCAVE + tcave_adj
-			local tmantle = mapgen.CENTER_REGION_LIMIT + centerRegionLimit_adj
-			local cavern_noise_adj =
-				mapgen.CENTER_REGION_LIMIT * (cavern_limit_distance * cavern_limit_distance * cavern_limit_distance) -
-				centerRegionLimit_adj -- cavern_noise_adj gets added to noise value instead of added to the limit np_noise is compared against, so subtract centerRegionLimit_adj so subtract centerRegionLimit_adj instead of adding
+			local regionLabels = {
+				[mapgen.RegionEnum.Overworld]     = "The Overworld",
+				[mapgen.RegionEnum.Positive]      = "Positive nether",
+				[mapgen.RegionEnum.PositiveShell] = "Shell between positive nether and center region",
+				[mapgen.RegionEnum.Center]        = "Center/Mantle, inside cavern",
+				[mapgen.RegionEnum.CenterShell]   = "Center/Mantle, but outside the caverns",
+				[mapgen.RegionEnum.Negative]      = "Negative nether",
+				[mapgen.RegionEnum.NegativeShell] = "Shell between negative nether and center region"
+			}
+			local desc = regionLabels[region]
 
-			local desc
-
-			if densityNoise > tcave then
-				desc = "Positive nether"
-			elseif -densityNoise > tcave then
-				desc = "Negative nether"
-			elseif math_abs(densityNoise) < tmantle then
-				desc =  "Mantle"
-
-				if math_abs(densityNoise) + cavern_noise_adj < mapgen.CENTER_CAVERN_LIMIT then
-					desc =  desc .. " inside cavern"
-				else
-					desc =  desc .. " but outside cavern"
-				end
-
-			elseif densityNoise > 0 then
-				desc =  "Shell between positive nether and center region"
-			else
-				desc = "Shell between negative nether and center region"
-			end
-
-			local sea_pos = pos.y - sea_level
+			local sea_pos = playerPos.y - seaLevel
 			if sea_pos > 0 then
 				desc = desc .. ", " .. sea_pos .. "m above lava-sea level"
 			else
@@ -470,7 +501,7 @@ minetest.register_chatcommand("nether_whereami",
 				desc = desc .. ", approaching y boundary of Nether"
 			end
 
-			return true, "[Perlin " .. (math_floor(densityNoise * 1000) / 1000) .. "] " .. desc
+			return true, "[Perlin " .. (math_floor(caveNoise * 1000) / 1000) .. "] " .. desc
 		end
 	}
 )

--- a/mod.conf
+++ b/mod.conf
@@ -1,4 +1,4 @@
 name = nether
 description = Adds a deep underground realm with different mapgen that you can reach with obsidian portals.
 depends = stairs, default
-optional_depends = moreblocks, mesecons, loot, dungeon_loot, doc_basics, fire
+optional_depends = moreblocks, mesecons, loot, dungeon_loot, doc_basics, fire, climate_api


### PR DESCRIPTION
Add appropriate/atmospheric distance fog to the nether, via [climate_api](https://github.com/t-affeldt/climate_api) mod to avoid conflicting with other mods.
Any game or server with climate_api mod installed will be expecting climate_api to take control of sky values.

Skylayer is another mod which could perform that role, but supporting it will require a little more code - see comments in code.

There's also some related refactoring.


![nether-fog](https://user-images.githubusercontent.com/6390507/107110989-73b17d80-68a0-11eb-8efb-2942833b448e.jpg)
My screenshots are often too dark when displayed on other devices, so the shot above probably isn't representative of how it looks in-game.

