### PR TITLE
Use Minetest_game fences API if it's available

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ the nether first, or basalt might be a crafting ingredient required to reach
 a particular branch of the tech-tree.
 
 Netherbrick tools are provided (pick, shovel, axe, & sword), see tools.lua
-The Nether pickaxe has a 10x bonus again wear when mining netherrack.
+The Nether pickaxe has a 10x bonus against wear when mining netherrack.
 
 
 ## License of source code:

--- a/locale/nether.fr.tr
+++ b/locale/nether.fr.tr
@@ -66,6 +66,7 @@ Lava crust is strong enough to walk on, but still hot enough to inflict burns.=
 Nether Basalt=
 Nether Brick=Brique du Nether
 Nether Brick Fence=Barrière en briques du Nether
+Nether Brick Fence Rail=Clôture en briques du Nether
 Nether Slab=Dalle du Nether
 Nether Stair=Escalier du Nether
 Netherrack=Roche du Nether

--- a/locale/template.txt
+++ b/locale/template.txt
@@ -65,6 +65,7 @@ Lava crust is strong enough to walk on, but still hot enough to inflict burns.=
 Nether Basalt=
 Nether Brick=
 Nether Brick Fence=
+Nether Brick Fence Rail=
 Nether Slab=
 Nether Stair=
 Netherrack=

--- a/nodes.lua
+++ b/nodes.lua
@@ -249,26 +249,6 @@ minetest.register_node("nether:brick_cracked", {
 	sounds = default.node_sound_stone_defaults(),
 })
 
-local fence_texture =
-	"default_fence_overlay.png^nether_brick.png^default_fence_overlay.png^[makealpha:255,126,126"
-
-minetest.register_node("nether:fence_nether_brick", {
-	description = S("Nether Brick Fence"),
-	drawtype = "fencelike",
-	tiles = {"nether_brick.png"},
-	inventory_image = fence_texture,
-	wield_image = fence_texture,
-	paramtype = "light",
-	sunlight_propagates = true,
-	is_ground_content = false,
-	selection_box = {
-		type = "fixed",
-		fixed = {-1/7, -1/2, -1/7, 1/7, 1/2, 1/7},
-	},
-	groups = {cracky = 2, level = 2},
-	sounds = default.node_sound_stone_defaults(),
-})
-
 minetest.register_node("nether:brick_deep", {
 	description = S("Deep Nether Brick"),
 	tiles = {{
@@ -280,6 +260,55 @@ minetest.register_node("nether:brick_deep", {
 	groups = {cracky = 2, level = 2},
 	sounds = default.node_sound_stone_defaults()
 })
+
+-- Register fence and rails
+
+local fence_texture =
+	"default_fence_overlay.png^nether_brick.png^default_fence_overlay.png^[makealpha:255,126,126"
+
+if minetest.get_modpath("default") and minetest.global_exists("default") and default.register_fence ~= nil then
+	-- The Minetest_Game fences API is available,
+	-- using it adds interop between different fences, and the "Tall fences and walls" option.
+	default.register_fence("nether:fence_nether_brick", {
+		description = S("Nether Brick Fence"),
+		texture = "nether_brick.png",
+		inventory_image = fence_texture,
+		wield_image = fence_texture,
+		material = "nether:brick",
+		groups = {cracky = 2, level = 2},
+		sounds = default.node_sound_stone_defaults()
+	})
+
+	default.register_fence_rail("nether:fence_rail_nether_brick", {
+		description = S("Nether Brick Fence Rail"),
+		texture = "nether_brick.png",
+		inventory_image = "default_fence_rail_overlay.png^nether_brick.png^" ..
+					"default_fence_rail_overlay.png^[makealpha:255,126,126",
+		wield_image = "default_fence_rail_overlay.png^nether_brick.png^" ..
+					"default_fence_rail_overlay.png^[makealpha:255,126,126",
+		material = "nether:brick",
+		groups = {cracky = 2, level = 2},
+		sounds = default.node_sound_stone_defaults()
+	})
+else
+	-- Original nether fence code, preserved to avoid deeper coupling with MTG
+	minetest.register_node("nether:fence_nether_brick", {
+		description = S("Nether Brick Fence"),
+		drawtype = "fencelike",
+		tiles = {"nether_brick.png"},
+		inventory_image = fence_texture,
+		wield_image = fence_texture,
+		paramtype = "light",
+		sunlight_propagates = true,
+		is_ground_content = false,
+		selection_box = {
+			type = "fixed",
+			fixed = {-1/7, -1/2, -1/7, 1/7, 1/2, 1/7},
+		},
+		groups = {cracky = 2, level = 2},
+		sounds = default.node_sound_stone_defaults(),
+	})
+end
 
 -- Register stair and slab
 

--- a/nodes.lua
+++ b/nodes.lua
@@ -266,49 +266,28 @@ minetest.register_node("nether:brick_deep", {
 local fence_texture =
 	"default_fence_overlay.png^nether_brick.png^default_fence_overlay.png^[makealpha:255,126,126"
 
-if minetest.get_modpath("default") and minetest.global_exists("default") and default.register_fence ~= nil then
-	-- The Minetest_Game fences API is available,
-	-- using it adds interop between different fences, and the "Tall fences and walls" option.
-	default.register_fence("nether:fence_nether_brick", {
-		description = S("Nether Brick Fence"),
-		texture = "nether_brick.png",
-		inventory_image = fence_texture,
-		wield_image = fence_texture,
-		material = "nether:brick",
-		groups = {cracky = 2, level = 2},
-		sounds = default.node_sound_stone_defaults()
-	})
+local rail_texture =
+	"default_fence_rail_overlay.png^nether_brick.png^default_fence_rail_overlay.png^[makealpha:255,126,126"
 
-	default.register_fence_rail("nether:fence_rail_nether_brick", {
-		description = S("Nether Brick Fence Rail"),
-		texture = "nether_brick.png",
-		inventory_image = "default_fence_rail_overlay.png^nether_brick.png^" ..
-					"default_fence_rail_overlay.png^[makealpha:255,126,126",
-		wield_image = "default_fence_rail_overlay.png^nether_brick.png^" ..
-					"default_fence_rail_overlay.png^[makealpha:255,126,126",
-		material = "nether:brick",
-		groups = {cracky = 2, level = 2},
-		sounds = default.node_sound_stone_defaults()
-	})
-else
-	-- Original nether fence code, preserved to avoid deeper coupling with MTG
-	minetest.register_node("nether:fence_nether_brick", {
-		description = S("Nether Brick Fence"),
-		drawtype = "fencelike",
-		tiles = {"nether_brick.png"},
-		inventory_image = fence_texture,
-		wield_image = fence_texture,
-		paramtype = "light",
-		sunlight_propagates = true,
-		is_ground_content = false,
-		selection_box = {
-			type = "fixed",
-			fixed = {-1/7, -1/2, -1/7, 1/7, 1/2, 1/7},
-		},
-		groups = {cracky = 2, level = 2},
-		sounds = default.node_sound_stone_defaults(),
-	})
-end
+default.register_fence("nether:fence_nether_brick", {
+	description = S("Nether Brick Fence"),
+	texture = "nether_brick.png",
+	inventory_image = fence_texture,
+	wield_image = fence_texture,
+	material = "nether:brick",
+	groups = {cracky = 2, level = 2},
+	sounds = default.node_sound_stone_defaults()
+})
+
+default.register_fence_rail("nether:fence_rail_nether_brick", {
+	description = S("Nether Brick Fence Rail"),
+	texture = "nether_brick.png",
+	inventory_image = rail_texture,
+	wield_image = rail_texture,
+	material = "nether:brick",
+	groups = {cracky = 2, level = 2},
+	sounds = default.node_sound_stone_defaults()
+})
 
 -- Register stair and slab
 


### PR DESCRIPTION
Fixes #56, and adds netherbrick rails (for consistency with MTG) ~~if the fences API is found.~~
Using the MTG fence system adds interop between different fence types, and support for the "Tall fences and walls" option.

I've left the nether's register_craft() call unchanged, it overrides the recipe that default.register_fence() registers, granting 6 fences per crafting instead of MTG's 4.