### PR TITLE
fix the sky in the nether caverns when using climate_api

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -312,7 +312,7 @@ The expedition parties have found no diamonds or gold, and after an experienced 
 		geodeSky.sky_data.base_color  = nether.fogColor.geodes
 
 		climate_api.register_weather(
-			"nether:nether",
+			"nether:caverns",
 			{ nether_biome = "nether" },
 			{ ["climate_api:skybox"] = netherSky }
 		)


### PR DESCRIPTION
I'll merge this in a couple of days if nobody has commented or merged it themselves

---
Climate_API can help a little with a lighting problem recently raised on the forums, so I went to get a screenshot of nether with climate_api mod running... and it didn't work.

The mantle and geode skys were working correctly, but not the sky in the main nether area - it would always switch back to stars. This fix was found by process of elimination, so I don't know why climate_api doesn't accept "nether:nether" as a unique weather name identifier, or how this issue wasn't noticed earlier (did something change?).

climate_api's api_doc.md file says the name:
>should be prefixed with the mod's name in a way that could look like ``mymod:awesome_weather``. This name should only be used once.

so perhaps names of the form `"mymod:mymod"` causes issues? (I don't plan on figuring out why climate_api behaves this way though)