### PR TITLE
Avoid Unknown nodes under the nether bug

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -58,7 +58,7 @@ nether.fogColor = {	           -- only used if climate_api is installed
 
 -- Settings
 nether.DEPTH_CEILING              =  -5000 -- The y location of the Nether's celing
-nether.DEPTH_FLOOR                = -11000 -- The y location of the Nether's floor
+nether.DEPTH_FLOOR                = -11072 -- The y location of the Nether's floor - set on a chunk boundary rather than a nice round -11000 to avoid https://github.com/minetest-mods/nether/issues/51
 nether.FASTTRAVEL_FACTOR          =      8 -- 10 could be better value for Minetest, since there's no sprint, but ex-Minecraft players will be mathing for 8
 nether.PORTAL_BOOK_LOOT_WEIGHTING =    0.9 -- Likelyhood of finding the Book of Portals (guide) in dungeon chests. Set to 0 to disable.
 nether.NETHER_REALM_ENABLED       =   true -- Setting to false disables the Nether and Nether portal

--- a/settingtypes.txt
+++ b/settingtypes.txt
@@ -3,7 +3,7 @@
 # A factor of 10 might be a better value for Minetest, since there's no sprint, but ex-Minecraft players will be mathing for 8.
 nether_fasttravel_factor (Nether fast-travel factor) int 8
 
-# The likelyhood of finding a Book containing all the portal plans in a dungeon chest. 
+# The likelyhood of finding a Book containing all the portal plans in a dungeon chest.
 # Set to 0 to disable, or 10 to have it extremely common.
 #
 # (This value will be treated as 0 when the Nether portal is the only type of portal available, or when the help modpack is installed)
@@ -21,5 +21,5 @@ nether_enable_portal_example_surfacetravel (Enable example portal: Surface-trave
 [Nether depth]
 #The depth where the Nether begins / the Nether ceiling
 nether_depth_ymax (Upper limit of Nether) int -5000 -30000 32767
-#The lower limit of the Nether must be at least 1000 lower than the upper limit, and more than 3000 lower is recommended.
-nether_depth_ymin (Lower limit of Nether) int -11000 -32768 30000
+#The lower limit of the Nether must be at least 1000 lower than the upper limit, and more than 3000 lower is recommended. A value that's on a chunk boundary is also recommended.
+nether_depth_ymin (Lower limit of Nether) int -11072 -32768 30000


### PR DESCRIPTION
Hides bug #51 - the node_stone of the biome appears in the whole chunk under the Nether, so make the nether occupy the whole chunk.

I was loath to do this because the nether will extend 72 blocks further down by default, and perhaps a server is counting on that default and has used the space for something else but not actually set the nether floor setting and so is depending on the default value.

But bug #51 seems to cause a lot of consternation, and the sooner it's changed the fewer servers will be affected.

I've also raised [an engine bug ticket](https://github.com/minetest/minetest/issues/13440)